### PR TITLE
Improving Untiled Window Handling

### DIFF
--- a/quicktile.py
+++ b/quicktile.py
@@ -306,7 +306,7 @@ class WindowManager(object):
         # If the window is already on one of the configured geometries, advance
         # to the next configuration. Otherwise, use the first configuration.
         min_distance = heappop(euclid_distance)
-        if min_distance[0] < 25:
+        if min_distance[0] < 100:
             pos = (min_distance[1] + 1) % len(dims)
         else:
             pos = 0


### PR DESCRIPTION
The current behavior for untiled windows seems a bit unintuitive. This change makes untiled windows always start on the first configuration.

Implementation notes:
- The closest current configuration is still picked the same way.
- If the window is already on a configuration switch to the next. Otherwise use the first.
- Some windows, such as terminals or editors resizes in chunks, so "on a configuration" is loosely defined as within 500 pixels in Euclidean distance.
