### PR TITLE
Fixed using uninitialized variable

### DIFF
--- a/quicktile.py
+++ b/quicktile.py
@@ -863,7 +863,7 @@ class KeyBinder(object):
 
                 else:
                     logging.error("Received an event for an unrecognized "
-                                  "keybind: %s, %s", xevent.detail, mmask)
+                                  "keybind: %s, %s", xevent.detail, xevent.state)
 
         # Necessary for proper function
         return True


### PR DESCRIPTION
Replaced the access to the unused variable mmask with the state of xevent. This bug crashed my quicktile after a while :).