### PR TITLE
Fix left-right size cycling for large monitors

### DIFF
--- a/quicktile.py
+++ b/quicktile.py
@@ -1119,7 +1119,7 @@ def cycle_dimensions(winman, win, state, *dimensions):
     # If the window is already on one of the configured geometries, advance
     # to the next configuration. Otherwise, use the first configuration.
     min_distance = heappop(euclid_distance)
-    if min_distance[0] < 100:
+    if float(min_distance[0]) / tuple(clip_box)[2] < 0.1:
         pos = (min_distance[1] + 1) % len(dims)
     else:
         pos = 0


### PR DESCRIPTION
For large monitors, size cycling for left/right was not working due to the euclidian distance between the ideal first state and the actually-used first state being too large (over the previously defined constant value of 100).  This commit changes the calculation to compare the calculated euclidian distance to the monitor width to allow it to work with monitors of different sizes.

Tested on a variety of different resolutions.