### PR TITLE
Use round for pixel numbers calculations

### DIFF
--- a/quicktile.py
+++ b/quicktile.py
@@ -160,10 +160,10 @@ class GravityLayout(object):  # pylint: disable=too-few-public-methods
         offset_x = w * self.GRAVITIES[gravity][0]
         offset_y = h * self.GRAVITIES[gravity][1]
 
-        return (x - offset_x + self.margin_x,
-                y - offset_y + self.margin_y,
-                w - (self.margin_x * 2),
-                h - (self.margin_y * 2))
+        return (round(x - offset_x + self.margin_x, 3),
+                round(y - offset_y + self.margin_y, 3),
+                round(w - (self.margin_x * 2), 3),
+                round(h - (self.margin_y * 2), 3))
 
 #: Number of columns to base generated L{POSITIONS} presets on
 #: @todo: Store COLUMN_COUNT in quicktile.cfg for easy editing
@@ -178,7 +178,7 @@ def _make_positions():
     # TODO: Plumb GravityLayout.__init__'s arguments into the config file
     gvlay = GravityLayout()
     col_width = 1.0 / COLUMN_COUNT
-    cycle_steps = tuple(col_width * x for x in range(1, COLUMN_COUNT))
+    cycle_steps = tuple(round(col_width * x, 3) for x in range(1, COLUMN_COUNT))
 
     edge_steps = (1.0,) + cycle_steps
     corner_steps = (0.5,) + cycle_steps


### PR DESCRIPTION
Without this for certain `COLUMN_COUNT` values, I see the following `positions`:

```
('positions', {
  'right': [(0.5, 0.0, 0.5, 1), (0.9, 0.0, 0.1, 1), (0.8, 0.0, 0.2, 1), (0.7, 0.0, 0.3, 1), (0.6, 0.0, 0.4, 1), (0.5, 0.0, 0.5, 1), (0.4, 0.0, 0.6, 1), (0.30000000000000004, 0.0, 0.7, 1), (0.19999999999999996, 0.0, 0.8, 1), (0.09999999999999998, 0.0, 0.9, 1)],
  'bottom': [(0.0, 0.5, 1.0, 0.5), (0.45, 0.5, 0.1, 0.5), (0.4, 0.5, 0.2, 0.5), (0.35, 0.5, 0.3, 0.5), (0.3, 0.5, 0.4, 0.5), (0.25, 0.5, 0.5, 0.5), (0.2, 0.5, 0.6, 0.5), (0.15000000000000002, 0.5, 0.7, 0.5), (0.09999999999999998, 0.5, 0.8, 0.5), (0.04999999999999999, 0.5, 0.9, 0.5)],
  'top': [(0.0, 0.0, 1.0, 0.5), (0.45, 0.0, 0.1, 0.5), (0.4, 0.0, 0.2, 0.5), (0.35, 0.0, 0.3, 0.5), (0.3, 0.0, 0.4, 0.5), (0.25, 0.0, 0.5, 0.5), (0.2, 0.0, 0.6, 0.5), (0.15000000000000002, 0.0, 0.7, 0.5), (0.09999999999999998, 0.0, 0.8, 0.5), (0.04999999999999999, 0.0, 0.9, 0.5)],
  'middle': [(0.0, 0.0, 1.0, 1), (0.45, 0.0, 0.1, 1), (0.4, 0.0, 0.2, 1), (0.35, 0.0, 0.3, 1), (0.3, 0.0, 0.4, 1), (0.25, 0.0, 0.5, 1), (0.2, 0.0, 0.6, 1), (0.15000000000000002, 0.0, 0.7, 1), (0.09999999999999998, 0.0, 0.8, 1), (0.04999999999999999, 0.0, 0.9, 1)],
  'bottom-right': [(0.5, 0.5, 0.5, 0.5), (0.9, 0.5, 0.1, 0.5), (0.8, 0.5, 0.2, 0.5), (0.7, 0.5, 0.3, 0.5), (0.6, 0.5, 0.4, 0.5), (0.5, 0.5, 0.5, 0.5), (0.4, 0.5, 0.6, 0.5), (0.30000000000000004, 0.5, 0.7, 0.5), (0.19999999999999996, 0.5, 0.8, 0.5), (0.09999999999999998, 0.5, 0.9, 0.5)],
  'bottom-left': [(0.0, 0.5, 0.5, 0.5), (0.0, 0.5, 0.1, 0.5), (0.0, 0.5, 0.2, 0.5), (0.0, 0.5, 0.3, 0.5), (0.0, 0.5, 0.4, 0.5), (0.0, 0.5, 0.5, 0.5), (0.0, 0.5, 0.6, 0.5), (0.0, 0.5, 0.7, 0.5), (0.0, 0.5, 0.8, 0.5), (0.0, 0.5, 0.9, 0.5)],
  'top-right': [(0.5, 0.0, 0.5, 0.5), (0.9, 0.0, 0.1, 0.5), (0.8, 0.0, 0.2, 0.5), (0.7, 0.0, 0.3, 0.5), (0.6, 0.0, 0.4, 0.5), (0.5, 0.0, 0.5, 0.5), (0.4, 0.0, 0.6, 0.5), (0.30000000000000004, 0.0, 0.7, 0.5), (0.19999999999999996, 0.0, 0.8, 0.5), (0.09999999999999998, 0.0, 0.9, 0.5)],
  'top-left': [(0.0, 0.0, 0.5, 0.5), (0.0, 0.0, 0.1, 0.5), (0.0, 0.0, 0.2, 0.5), (0.0, 0.0, 0.3, 0.5), (0.0, 0.0, 0.4, 0.5), (0.0, 0.0, 0.5, 0.5), (0.0, 0.0, 0.6, 0.5), (0.0, 0.0, 0.7, 0.5), (0.0, 0.0, 0.8, 0.5), (0.0, 0.0, 0.9, 0.5)],
  'left': [(0.0, 0.0, 0.5, 1), (0.0, 0.0, 0.1, 1), (0.0, 0.0, 0.2, 1), (0.0, 0.0, 0.3, 1), (0.0, 0.0, 0.4, 1), (0.0, 0.0, 0.5, 1), (0.0, 0.0, 0.6, 1), (0.0, 0.0, 0.7, 1), (0.0, 0.0, 0.8, 1), (0.0, 0.0, 0.9, 1)]
})
```