### PR TITLE
Fix edge_steps unique values

### DIFF
--- a/quicktile/layout.py
+++ b/quicktile/layout.py
@@ -88,7 +88,7 @@ def make_winsplit_positions(columns):
                         for x in range(1, columns))
 
     middle_steps = (1.0,) + cycle_steps
-    edge_steps = (0.5,) + cycle_steps
+    edge_steps = tuple(sorted(set((0.5,) + cycle_steps)))
 
     positions = {
         'middle': [gvlay(width, 1, 'middle') for width in middle_steps],


### PR DESCRIPTION
For `ColumnCount = 8`, `edge_steps` contain a double value for `0.5`, which makes windows cycle only between `0.125` and `0.5` of the screen width.

Before:
```
DEBUG: edge_steps (0.5, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875)
```

After:
```
DEBUG: edge_steps (0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875)
```