### PR TITLE
Add config setting for margin between windows

### DIFF
--- a/quicktile/__main__.py
+++ b/quicktile/__main__.py
@@ -43,7 +43,9 @@ DEFAULTS = {
         'ModMask': '<Ctrl><Alt>',
         'UseWorkarea': True,
         'MovementsWrap': True,
-        'ColumnCount': 3
+        'ColumnCount': 3,
+        'MarginX': 0.0,
+        'MarginY': 0.0,
     },
     'keys': {
         "KP_Enter": "monitor-switch",
@@ -281,7 +283,7 @@ def main():  # type: () -> None
 
     # TODO: Rearchitect so this hack isn't needed
     commands.cycle_dimensions = commands.commands.add_many(
-        layout.make_winsplit_positions(config.getint('general', 'ColumnCount'))
+        layout.make_winsplit_positions(config.getint('general', 'ColumnCount'), config.getfloat('general', 'MarginX'), config.getfloat('general', 'MarginY'))
     )(commands.cycle_dimensions)
     commands.commands.extra_state = {'config': config}
 

--- a/quicktile/__main__.py
+++ b/quicktile/__main__.py
@@ -46,6 +46,7 @@ DEFAULTS = {
         'ColumnCount': 3,
         'MarginX': 0.0,
         'MarginY': 0.0,
+        'NoMarginAtEdges': False
     },
     'keys': {
         "KP_Enter": "monitor-switch",
@@ -282,8 +283,14 @@ def main():  # type: () -> None
                        opts.no_workarea)
 
     # TODO: Rearchitect so this hack isn't needed
+    
+    column_count = config.getint('general', 'ColumnCount')
+    margin_x = config.getfloat('general', 'MarginX')
+    margin_y = config.getfloat('general', 'MarginY')
+    no_margin_at_edges = config.getboolean('general', 'NoMarginAtEdges')
+    
     commands.cycle_dimensions = commands.commands.add_many(
-        layout.make_winsplit_positions(config.getint('general', 'ColumnCount'), config.getfloat('general', 'MarginX'), config.getfloat('general', 'MarginY'))
+        layout.make_winsplit_positions(column_count, margin_x, margin_y, no_margin_at_edges)
     )(commands.cycle_dimensions)
     commands.commands.extra_state = {'config': config}
 

--- a/quicktile/layout.py
+++ b/quicktile/layout.py
@@ -98,7 +98,7 @@ class GravityLayout(object):  # pylint: disable=too-few-public-methods
         'bottom-right': (1.0, 1.0),
     }  # type: Dict[str, Tuple[float, float]]
 
-    def __init__(self, margin_x=0, margin_y=0):  # type: (int, int) -> None
+    def __init__(self, margin_x=0.0, margin_y=0.0):  # type: (float, float) -> None
         """
         @param margin_x: Horizontal margin to apply when calculating window
             positions, as decimal percentage of screen width.
@@ -154,15 +154,14 @@ class GravityLayout(object):  # pylint: disable=too-few-public-methods
                 round(width - (self.margin_x * 2), 3),
                 round(height - (self.margin_y * 2), 3))
 
-def make_winsplit_positions(columns):
-    # type: (int) -> Dict[str, List[PercentRect]]
+def make_winsplit_positions(columns, marginX, marginY):
+    # type: (int, float, float) -> Dict[str, List[PercentRect]]
     """Generate the classic WinSplit Revolution tiling presets
 
     @todo: Figure out how best to put this in the config file.
     """
 
-    # TODO: Plumb GravityLayout.__init__'s arguments into the config file
-    gvlay = GravityLayout()
+    gvlay = GravityLayout(marginX, marginY)
     col_width = 1.0 / columns
     cycle_steps = tuple(round(col_width * x, 3)
                         for x in range(1, columns))


### PR DESCRIPTION
This PR adds configuration options to specify a gap that will be placed between tiled windows.

The settings "MarginX" and "MarginY" specify the gap (in decimal % of screen size) that will be placed on each side of a window, and the setting "NoMarginAtEdges" determines whether a margin is placed between a window and an edge of the screen (in other words, if this setting is true then windows will stick to the edge of the screen but still have gaps between each other).