### PR TITLE
Update README: install python-xlib on Fedora

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,13 +67,13 @@ following commands to easily install them:
 
 .. code:: sh
 
-    sudo dnf install python pygtk2 pygobject2 dbus-python gnome-python2-libwnck
+    sudo dnf install python pygtk2 pygobject2 dbus-python gnome-python2-libwnck python-xlib
 
 **Fedora 21 and below:**
 
 .. code:: sh
 
-    sudo yum install python pygtk2 pygobject2 dbus-python gnome-python2-libwnck
+    sudo yum install python pygtk2 pygobject2 dbus-python gnome-python2-libwnck python-xlib
 
 --------------------------
 Installation (Typical Use)


### PR DESCRIPTION
At least on CentOS 7 the (optional) python-xlib dependency must be installed manually.