### PR TITLE
Don't create files with root perms on non-root pip cache directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ QuickTile can be run from the source folder without installation via the
 For system-wide installation, the recommended option is ``pip3``, which will
 record a log to allow easy uninstallation.
 
-``sudo pip3 install https://github.com/ssokolow/quicktile/archive/master.zip``
+``sudo -H pip3 install https://github.com/ssokolow/quicktile/archive/master.zip``
 
 QuickTile's dependence on PyGObject prevents a fully PyPI-based installation
 option.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -118,7 +118,7 @@ QuickTile:
 
 .. code:: sh
 
-    sudo pip3 install https://github.com/ssokolow/quicktile/archive/master.zip
+    sudo -H pip3 install https://github.com/ssokolow/quicktile/archive/master.zip
 
 .. note:: If you attempt to use the ``--upgrade`` option and it fails to
     properly ignore system-provided dependencies, follow the instructions

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [ "$(id -u)" != 0 ]; then
     python3 setup.py build
 
     echo "* Acquiring permissions to perform system-wide install"
-    exec sudo "$0" "$@"
+    exec sudo -H "$0" "$@"
 fi
 
 echo "* Attempting to remove old QuickTile installs"


### PR DESCRIPTION
# Description

This pr update the docs and some scripts to include `-H` argument on `sudo` when using pip to avoid creating files with root permissions on non-root pip cache directory

# Rationale

After pip 6.0.0 (I don't remember which exact version this was included with.), by default pip creates a cache directory in `$HOME/.cache/pip/` and store the wheel/egg packages. The `$HOME` is the current user home directory.

When we use:

```bash
sudo pip3 install some-package
```

`pip` will continue to use the current user's pip cache directory, however, new files and directories within the cache folder will be created with the owner defined as `root`, that is, we will end up having files and a directory inside the current user home that the current user cannot read or write without root permission.

This is not a problem that pip can solve on its own.
This is where the `sudo` `-H` argument comes in.
The best explanation of what `-H` does comes from the `sudo` documentation

```
     -H, --set-home
                 Request that the security policy set the HOME environment variable to the home
                 directory specified by the target user's password database entry.
```

That is, with `sudo -H` pip will use `/root/.cache/pip` instead of `/home/<my-user>/.cache/pip/`.

Whenever we need to install some python package with `pip` and `sudo` is necessary, it is recommended to use `-H` in `sudo` to avoid future headaches.
