### PR TITLE
Add Gtk.init to make it work on openSUSE Leap 15.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,6 +72,10 @@ Valentin Agachi
 Yuting/Tim Xiao
    Made the window-tiling heuristics more robust.
 
+Fritz Reichwald
+   Added "Gtk.init_check" in "quicktile.__main__" to work around a bug
+   in some builds of GTK.
+
 
 The Manual
 ==========

--- a/docs/authors/index.rst
+++ b/docs/authors/index.rst
@@ -76,6 +76,11 @@ Justin
 `Yuting/Tim Xiao`_
     Made the window-tiling heuristics more robust.
 
+`Fritz Reichwald`_
+    Added ``Gtk.init_check`` in ``quicktile.__main__`` to work around a 
+    bug in some builds of GTK.
+
+
 The Manual
 ----------
 
@@ -156,6 +161,7 @@ only to display favicon-style links to their owners' websites.
 .. _Valdis Vitolins: https://github.com/valdisvi
 .. _Valentin Agachi: https://github.com/avaly
 .. _Yuting/Tim Xiao: https://github.com/txiao
+.. _Fritz Reichwald: https://github.com/fiete201
 
 ..
     NOTE: For "Yuting/Tim Xiao", the commits are signed "Yuting Xiao" but the

--- a/quicktile/__main__.py
+++ b/quicktile/__main__.py
@@ -378,6 +378,10 @@ def main() -> None:
                         " file and rebooting."
                         % err.__class__.__name__)
 
+    # Work around a "the Gtk.Application ::startup handler does it for you" bug
+    if not Gtk.init_check():
+        raise XInitError("Gtk failed to connect to the X server. Cannot start.")
+
     try:
         winman = WindowManager(x_display=x_display)
     except XInitError as err:


### PR DESCRIPTION
Just faced an issue on openSUSE Leap 15.2 where quicktile told me that it can't connect to X.
```
libgobject-2_0-0 in Version 2.62.6-lp152.2.6.1
libgtk-3-0 in Version 3.24.20-lp152.2.3.1
python3 in Version 3.6.12-lp152.4.17.1
```

After I did this change it worked. Seems that with the versions on my openSUSE tumbleweed work without the explicit init. (The change does no harm on my tumbleweed machine so it may work for everyone?)
```
libgobject-2_0-0 in Version 2.68.1-1.1
libgtk-3-0 in Version 3.24.29-1.1
python38 in Version 3.8.10-1.1
```

Hope that this might help somehow.

Cheers fiete
