### PR TITLE
Get rid of 'PyGIWarning: GdkX11 was imported without specifying a ver…

### DIFF
--- a/quicktile/commands.py
+++ b/quicktile/commands.py
@@ -18,6 +18,7 @@ from Xlib import Xatom
 
 import gi
 gi.require_version('Gdk', '3.0')
+gi.require_version('GdkX11', '3.0')
 gi.require_version('Wnck', '3.0')
 
 from gi.repository import Gdk, GdkX11, Wnck


### PR DESCRIPTION
…sion first.'

fixes:
```
commands.py:23: PyGIWarning: GdkX11 was imported without specifying a version first. Use gi.require_version('GdkX11', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gdk, GdkX11, Wnck
```