### PR TITLE
Add command to goto certain position

### DIFF
--- a/quicktile/__main__.py
+++ b/quicktile/__main__.py
@@ -359,6 +359,15 @@ def main() -> None:
     commands.cycle_dimensions = commands.commands.add_many(
         layout.make_winsplit_positions(config.getint('general', 'ColumnCount'))
     )(commands.cycle_dimensions)
+
+    goto_commands = {}
+    for dim_dividend in range(1, config.getint('general', 'ColumnCount')+1):
+        for dim_divisor in range(1, config.getint('general', 'ColumnCount')+1):
+            for col in range(1, dim_divisor+1):
+                for addition, y_col in {'': None, '-top': 'top', '-bottom': 'bottom'}.items():
+                    goto_commands[f'goto-{dim_dividend}/{dim_divisor}-{col}{addition}'] = (dim_dividend, dim_divisor, col, y_col)
+    commands.goto_position_dimension = commands.commands.add_many(goto_commands)(commands.goto_position_dimension)
+
     commands.commands.extra_state = {'config': config}
 
     GLib.log_set_handler('Wnck', GLib.LogLevelFlags.LEVEL_WARNING,


### PR DESCRIPTION
This PR adds a new command to goto a certain grid position, without cycling through the different dimensions. For example if you want to have a screen on the left 1/3 you have to run the left command twice. However with this new command you can run `goto-1/3-1`. If you want to have the 2/3 you currently have to run the left command 3 times, now you can do `goto-2/3-1`. If you want it in the upper 2/3 in the right corner you can run `goto-2/3-2-top`.

The code does automatically adapt to the amount of columns that are defined. Some of the commands might be duplicate (like goto-2/4-1 and goto-1/2-1 are the same), but that is not an issue I suspect. 

Would really love to receive some feedback on this idea